### PR TITLE
New release: v9.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2021-XX-XX
 
+## [v9.0.1] 2021-11-26
+
 - [fix] Fixes issue with default payment card that was created by PR #111. Essentially, before
   confirming PaymentIntent, we now check if the PaymentIntent has already been confirmed.
   [#121](https://github.com/sharetribe/ftw-product/pull/121)
@@ -21,6 +23,8 @@ way to update this template, but currently, we follow a pattern:
   [#120](https://github.com/sharetribe/ftw-product/pull/120)
 - [fix] Temporarily disallow Node v17, since it causes issues with dependencies.
   [#119](https://github.com/sharetribe/ftw-product/pull/119)
+
+  [v9.0.1]: https://github.com/sharetribe/ftw-product/compare/v9.0.0...v9.0.1
 
 ## [v9.0.0] 2021-09-30
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
Bug fix for default payment method usage that caused 409 with Stripe message:
_"You cannot provide a new payment method to a PaymentIntent when it has a status of requires_capture. You should either capture the remaining funds, or cancel this PaymentIntent and try again with a new PaymentIntent."_

Essentially, before confirming PaymentIntent, we now check if the PaymentIntent has already been confirmed (which might be done for default payment method).

Note: this should also remove the earlier warning that confirming already confirmed PaymentIntent is unnecessary.

(The bug was introduced after fixing another bug just before release...)

Changelog entries:
- [fix] Fixes issue with default payment card that was created by PR 111. Essentially, before
  confirming PaymentIntent, we now check if the PaymentIntent has already been confirmed.
  [#121](https://github.com/sharetribe/ftw-product/pull/121)
- [fix] StripePaymentForm: add missing optional chaining: defaultPaymentMethod?.id
  [#120](https://github.com/sharetribe/ftw-product/pull/120)
- [fix] Temporarily disallow Node v17, since it causes issues with dependencies.
  [#119](https://github.com/sharetribe/ftw-product/pull/119)
