### PR TITLE
Update ProductOrderForm.js

### DIFF
--- a/src/components/OrderPanel/ProductOrderForm/ProductOrderForm.js
+++ b/src/components/OrderPanel/ProductOrderForm/ProductOrderForm.js
@@ -203,9 +203,11 @@ const ProductOrderForm = props => {
   // Should not happen for listings that go through EditListingWizard.
   // However, this might happen for imported listings.
   if (!pickupEnabled && !shippingEnabled) {
-    <p className={css.error}>
-      <FormattedMessage id="ProductOrderForm.noDeliveryMethodSet" />
-    </p>;
+    return (
+      <p className={css.error}>
+        <FormattedMessage id="ProductOrderForm.noDeliveryMethodSet" />
+      </p>
+    );
   }
 
   if (!price) {


### PR DESCRIPTION
Add a missing `return` to show warning about missing delivery method for imported listings