### PR TITLE
[Fix] Fix current bugs of the template

### DIFF
--- a/ext/transaction-process/process.edn
+++ b/ext/transaction-process/process.edn
@@ -261,7 +261,7 @@
    :template :order-canceled-from-disputed-customer}
   {:name :notification/canceled-from-disputed-provider,
    :on :transition/cancel-from-disputed,
-   :to :actor.role/customer,
+   :to :actor.role/provider,
    :template :order-canceled-from-disputed-provider}
   {:name :notification/auto-canceled-from-disputed-customer,
    :on :transition/auto-cancel-from-disputed,

--- a/src/containers/CheckoutPage/CheckoutPage.js
+++ b/src/containers/CheckoutPage/CheckoutPage.js
@@ -585,7 +585,7 @@ export class CheckoutPageComponent extends Component {
       message,
       paymentIntent,
       selectedPaymentMethod: paymentMethod,
-      saveAfterOnetimePayment: !!saveAfterOnetimePayment,
+      saveAfterOnetimePayment: Array.isArray(saveAfterOnetimePayment) && saveAfterOnetimePayment.length > 0 ? !!saveAfterOnetimePayment : null,
       ...shippingDetailsMaybe,
     };
 


### PR DESCRIPTION
- Bug 1: 
. Transition `cancel-from-disputed`
. Template: `canceled-from-disputed-provider`
. Current role: `customer`
. Expected role: `provider`

- Bug 2:
. If the box is checked and then unchecked, `saveAfterOnetimePayment` is already an array, so the condition `!!saveAfterOnetimePayment` will always be true even the checkbox is unchecked => The card will always be saved