### PR TITLE
New release v9.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,16 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2022-XX-XX
 
+## [v9.1.1] 2022-01-24
+
 - [fix] A full-page refresh on product when stock = 1 causes 500 error. SSR gets change request
   automatically from Final Form/FromSpy, and therefore window.fetch gets called on the server.
   [#133](https://github.com/sharetribe/ftw-product/pull/133)
+- [fix] Add a missing return statement on ProductOrderForm. The code path is relevant only for
+  listings that are created outside of EditListingWizard.
+  [#127](https://github.com/sharetribe/ftw-product/pull/127)
+
+  [v9.1.1]: https://github.com/sharetribe/ftw-product/compare/v9.1.0...v9.1.1
 
 ## [v9.1.0] 2021-12-02
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
- [fix] A full-page refresh on the listing page causes a '500' error when stock = 1 and there's no picker between delivery methods. SSR gets change requests automatically from Final Form/FromSpy, and therefore `window.fetch` gets called on the server.
  [#133](https://github.com/sharetribe/ftw-product/pull/133)
- [fix] Add a missing return statement on ProductOrderForm. The code path is relevant only for
  listings that are created outside of EditListingWizard.
  [#127](https://github.com/sharetribe/ftw-product/pull/127)
  
In addition, dependabot update for _follow-redirects_ nested dependency package was merged too.