### PR TITLE
Fix dispute notification role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2022-XX-XX
 
+- [fix] Process graph had an error: provider notification about dispute being canceled was not sent
+  to provider but customer. [#135](https://github.com/sharetribe/ftw-product/pull/135)
 - [fix] CheckoutPage: add missing link for fallback error, when submitting.
   [#137](https://github.com/sharetribe/ftw-product/pull/137)
 - [fix] CheckoutPage: if the saveAfterOnetimePayment checkbox is checked and then unchecked, the

--- a/ext/transaction-process/process.edn
+++ b/ext/transaction-process/process.edn
@@ -261,7 +261,7 @@
    :template :order-canceled-from-disputed-customer}
   {:name :notification/canceled-from-disputed-provider,
    :on :transition/cancel-from-disputed,
-   :to :actor.role/customer,
+   :to :actor.role/provider,
    :template :order-canceled-from-disputed-provider}
   {:name :notification/auto-canceled-from-disputed-customer,
    :on :transition/auto-cancel-from-disputed,


### PR DESCRIPTION
Note: this is just update to attached process.edn. _The actual fix would be to use `flex-cli` to update the process_ with a new version where "to" field is fixed: `:to :actor.role/provider`.

