### PR TITLE
Fix unselect of save card checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2022-XX-XX
 
+- [fix] CheckoutPage: if the saveAfterOnetimePayment checkbox is checked and then unchecked, the
+  value is already an array. [#136](https://github.com/sharetribe/ftw-product/pull/136)
+
 ## [v9.1.1] 2022-01-24
 
 - [fix] A full-page refresh on product when stock = 1 causes 500 error. SSR gets change request

--- a/src/containers/CheckoutPage/CheckoutPage.js
+++ b/src/containers/CheckoutPage/CheckoutPage.js
@@ -585,7 +585,8 @@ export class CheckoutPageComponent extends Component {
       message,
       paymentIntent,
       selectedPaymentMethod: paymentMethod,
-      saveAfterOnetimePayment: !!saveAfterOnetimePayment,
+      saveAfterOnetimePayment:
+        Array.isArray(saveAfterOnetimePayment) && saveAfterOnetimePayment.length > 0,
       ...shippingDetailsMaybe,
     };
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -907,6 +907,7 @@
   "StripePaymentForm.paymentCardDetails": "Payment card details",
   "StripePaymentForm.paymentHeading": "Payment",
   "StripePaymentForm.pickupDetailsTitle": "Pickup location",
+  "StripePaymentForm.pickupLocationUnknown": "Pickup location not set. Contact provider.",
   "StripePaymentForm.replaceAfterOnetimePayment": "Replace card …{last4Digits} with the new card for future bookings",
   "StripePaymentForm.sameBillingAndShippingAddress": "My billing and shipping address are the same",
   "StripePaymentForm.saveAfterOnetimePayment": "Save card details for future bookings",


### PR DESCRIPTION
CheckoutPage: if the saveAfterOnetimePayment checkbox is checked and then unchecked, the value is already an array (and an empty array is truthy in JS)