### PR TITLE
Fix invalid characters in csp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2022-XX-XX
 
+## [v9.3.1] 2022-05-19
+
+- [fix] undefined REACT_APP_GOOGLE_ANALYTICS_ID caused an error.
+  [#150](https://github.com/sharetribe/ftw-product/pull/150)
+
+  [v9.3.0]: https://github.com/sharetribe/ftw-product/compare/v9.3.0...v9.3.1
+
 ## [v9.3.0] 2022-05-19
 
 - [fix] undefined REACT_APP_GOOGLE_ANALYTICS_ID caused an error.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {

--- a/server/csp.js
+++ b/server/csp.js
@@ -32,7 +32,7 @@ const defaultDirectives = {
     'events.mapbox.com',
 
     // Google Analytics
-    '​www.​googletagm­anager.​com',
+    'www.googletagmanager.com',
     'www.google-analytics.com',
     'stats.g.doubleclick.net',
 
@@ -73,7 +73,7 @@ const defaultDirectives = {
     data,
     'maps.googleapis.com',
     'api.mapbox.com',
-    '​www.​googletagm­anager.​com',
+    'www.googletagmanager.com',
     '*.google-analytics.com',
     'js.stripe.com',
   ],


### PR DESCRIPTION
There were some invalid characters (zero-width space) in the CSP rule, which were added in v9.3.0.