### PR TITLE
New patch release: v10.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2022-XX-XX
 
+## [v10.0.1] 2022-07-11
+
+- ListingPage.test.js needed an update due to missing 'stock' in includes.
+
+  [v10.0.1]: https://github.com/sharetribe/ftw-product/compare/v10.0.0...v10.0.1
+
 ## [v10.0.0] 2022-07-11
 
 This is a major release since it includes a major update to sharetribe-scripts aka our fork of

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {

--- a/src/containers/ListingPage/ListingPage.test.js
+++ b/src/containers/ListingPage/ListingPage.test.js
@@ -127,7 +127,7 @@ describe('ListingPage', () => {
               id,
               'imageVariant.listing-card': 'w:400;h:400;fit:crop',
               'imageVariant.listing-card-2x': 'w:800;h:800;fit:crop',
-              include: ['author', 'author.profileImage', 'images'],
+              include: ['author', 'author.profileImage', 'images', 'currentStock'],
             }),
           ],
         ]);
@@ -155,7 +155,7 @@ describe('ListingPage', () => {
               id,
               'imageVariant.listing-card': 'w:400;h:400;fit:crop',
               'imageVariant.listing-card-2x': 'w:800;h:800;fit:crop',
-              include: ['author', 'author.profileImage', 'images'],
+              include: ['author', 'author.profileImage', 'images', 'currentStock'],
             }),
           ],
         ]);


### PR DESCRIPTION
ListingPage.test.js was failing due to missing 'currentStock' from Redux-related tests.