### PR TITLE
Update PasswordChangeForm.js

### DIFF
--- a/src/containers/PasswordChangePage/PasswordChangeForm/PasswordChangeForm.js
+++ b/src/containers/PasswordChangePage/PasswordChangeForm/PasswordChangeForm.js
@@ -173,7 +173,7 @@ class PasswordChangeFormComponent extends Component {
                 this.submittedValues = values;
                 handleSubmit(e)
                   .then(() => {
-                    this.resetTimeoutId = window.setTimeout(form.reset, RESET_TIMEOUT);
+                    this.resetTimeoutId = window.setTimeout(form.restart, RESET_TIMEOUT);
                   })
                   .catch(() => {
                     // Error is handled in duck file already.


### PR DESCRIPTION
`form.reset` triggers validation of the form after submission. Use `form.restart` instead.